### PR TITLE
returnディレクティブにおいて、相対URLを許容する変更

### DIFF
--- a/server_config/webserv.conf
+++ b/server_config/webserv.conf
@@ -5,6 +5,7 @@ server {
   location / {
     allow_method GET;
     root /app/www/;
+    return 400 /not_found_server.html;
   }
 }
 

--- a/srcs/config/ConfigParser.cpp
+++ b/srcs/config/ConfigParser.cpp
@@ -622,7 +622,20 @@ bool ConfigParser::IsValidLabel(const std::string &server_name,
 }
 
 bool ConfigParser::IsValidUrl(const std::string &url) {
-  // URL should start with http:// or https://
+  if (url.empty()) {
+    return false;
+  }
+
+  // Relative URL
+  if (url[0] == '/') {
+    if (IsValidPath(url)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // Absolute URL should start with http:// or https://
   if (url.substr(0, 7) != "http://" || url.substr(0, 8) != "https://") {
     return false;
   }


### PR DESCRIPTION
ソースコード及びconfigファイルの変更

例）
return 400 /not_found_server.html;